### PR TITLE
No.2 apps一覧画面での表示の不具合の修正

### DIFF
--- a/src/main/resources/static/css/app.css
+++ b/src/main/resources/static/css/app.css
@@ -4,7 +4,8 @@
 }
 
 .text-overflow {
-  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* 詳細 */

--- a/src/main/resources/templates/app/form.html
+++ b/src/main/resources/templates/app/form.html
@@ -14,6 +14,11 @@
         style='height: 200px; width: max-content;' />
     </div>
     <div class="form-group">
+      <label for="url">Url</label>
+      <input id="url" name="url" type="text" class="form-control" th:field="*{url}"
+        style='height: 200px; width: max-content;' />
+    </div>
+    <div class="form-group">
       <label for="description">Description</label>
       <input id="description" name="description" type="text" class="form-control" th:field="*{description}"
         style='height: 200px; width: max-content;' />


### PR DESCRIPTION
更新成功後に、List AppページでDiscription項目が他の項目に重なっていた為、
app/index.htmlのclass="text-overflow"に該当するcssを修正