### PR TITLE
No.11 カテゴリー商品紐付け画面での不具合

### DIFF
--- a/src/main/java/com/example/controller/CategoryController.java
+++ b/src/main/java/com/example/controller/CategoryController.java
@@ -74,7 +74,8 @@ public class CategoryController {
 			category = categoryService.save(entity);
 			redirectAttributes.addFlashAttribute("success", Message.MSG_SUCESS_INSERT);
 			redirectAttributes.addAttribute("q", "create");
-			return "category/productRelation";
+
+			return "redirect:/categories/" + category.getId() + "/productRelation";
 		} catch (Exception e) {
 			redirectAttributes.addFlashAttribute("error", Message.MSG_ERROR);
 			e.printStackTrace();

--- a/src/main/resources/static/js/category/category-product.js
+++ b/src/main/resources/static/js/category/category-product.js
@@ -3,12 +3,12 @@ $(document).ready(function () {
   let action = document.getElementById("action").getAttribute("val");
 
   $.ajax({
-    url: "/api/category/" + categoryId,
+    url: "/api/categories/" + categoryId,
     type: "GET",
     dataType: "json",
   })
     .done(function (data) {
-      var categoryProducts = data;
+      var categoryProducts = data.categoryProducts;
       // チェックボックスにチェックを入れる処理
       categoryProducts.forEach(function (categoryProduct) {
         $("#checkbox-" + categoryProduct.productId).prop("checked", true);
@@ -16,7 +16,10 @@ $(document).ready(function () {
     })
     .fail(function () {
       // APIコールが失敗した場合の処理
-      console.log("APIコールが失敗しました。");
+      var errorMessage = "APIコールが失敗しました。";
+
+      // エラーメッセージをブラウザに表示
+      $("#error-message").text(errorMessage).show().fadeOut(3000);
     });
 
   $("#update-button").click(function () {
@@ -42,7 +45,7 @@ $(document).ready(function () {
       type: "POST",
       dataType: "text",
       contentType: "application/json",
-      data: postData,
+      data: JSON.stringify(postData),
     }).done(function (data) {
       $("#success-message").text(data).show().fadeOut(3000);
     });


### PR DESCRIPTION
・カテゴリーを開いた際に紐付けされている商品のチェックボックスが入っていない。
=> 更新時と同様のリダイレクト処理に修正

・選択した商品を紐付け更新しようとしても更新が出来ない。
=>エンドポイントの指定が間違っていたので修正。(6行目)
forEachが利用できるようdataオブジェクトのcategoryProductsプロパティを指定。(11行目) JSONで受け取れるように、JSON形式に変換。(45行目)

・API通信が失敗した時はエラー表示してほしい。
=>コンソール表示をブラウザ表示できるよう修正。