### PR TITLE
No.14 商品一覧画面で複数カテゴリでの検索時にOR検索になっている。

### DIFF
--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -17,6 +17,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 
 import com.example.entity.ProductWithCategoryName;
 import com.example.form.ProductForm;
@@ -89,6 +90,19 @@ public class ProductService {
 		if (form.getCategories() != null && form.getCategories().size() > 0) {
 			// categories で完全一致検索
 			query.where(categoryJoin.get("id").in(form.getCategories()));
+			Subquery<Long> subquery = query.subquery(Long.class);
+			Root<Product> subRoot = subquery.from(Product.class);
+			Join<Product, CategoryProduct> subCategoryProductJoin = subRoot.join("categoryProducts", JoinType.LEFT);
+			Join<CategoryProduct, Category> subCategoryJoin = subCategoryProductJoin.join("category", JoinType.LEFT);
+			subquery.select(subRoot.get("id"))
+					.where(subCategoryJoin.get("id").in(form.getCategories()))
+					.groupBy(subRoot.get("id"))
+					.having(builder.equal(builder.count(subCategoryJoin), form.getCategories().size()));
+
+			// メインクエリの条件にサブクエリを適用する
+			query.where(builder.and(
+					builder.equal(root.get("shopId"), shopId),
+					builder.in(root.get("id")).value(subquery)));
 		}
 
 		// weight で範囲検索


### PR DESCRIPTION
search()
外部結合で取得した条件からさらにサブクエリを利用して、
複数選択時の検索要件をAND検索に切り替える。
89行目のカテゴリー選択時の要件を修正