### PR TITLE
No.16 取引金額のメモ欄の入力制御ができていない不具合の修正

### DIFF
--- a/src/main/java/com/example/constants/Validate.java
+++ b/src/main/java/com/example/constants/Validate.java
@@ -6,5 +6,6 @@ package com.example.constants;
 public final class Validate {
 	public static final Integer PRICE_UPPER = 1000000000;
 	public static final Integer EXPENSE_PRICE_UPPER = 500000000;
-	public static final Integer TEXT_LENGTH = 2000;
+	public static final Integer TEXT_LENGTH_1 = 2000;
+	public static final Integer TEXT_LENGTH_2 = 1000;
 }

--- a/src/main/java/com/example/service/TransactionAmountService.java
+++ b/src/main/java/com/example/service/TransactionAmountService.java
@@ -85,7 +85,7 @@ public class TransactionAmountService {
 		}
 		// メモは1000文字以下か
 		if (Objects.nonNull(entity.getMemo())) {
-			if (entity.getMemo().length() >= Validate.TEXT_LENGTH) {
+			if (entity.getMemo().length() > Validate.TEXT_LENGTH_2) {
 				return false;
 			}
 		}

--- a/src/main/java/com/example/utils/CheckUtil.java
+++ b/src/main/java/com/example/utils/CheckUtil.java
@@ -13,7 +13,7 @@ public class CheckUtil {
 	 */
 	public static boolean checkDescriptionLength(String description) {
 		// descriptionは2000文字以下か
-		if (Objects.nonNull(description) && description.length() > Validate.TEXT_LENGTH) {
+		if (Objects.nonNull(description) && description.length() > Validate.TEXT_LENGTH_1) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
・Validate.java で共通定数を使っているのでもう一つ定数を用意する
        public static final Integer TEXT_LENGTH_1 = 2000;
=> CheckUtil.javaで利用しているので定数名を変更して該当箇所も修正
        public static final Integer TEXT_LENGTH_2 = 1000;
=> 新しく用意
・entity.getMemo().length() >= Validate.TEXT_LENGTH 「>=」を「>」に修正