### PR TITLE
No.21 キャンペーン一覧でステータス一括更新時のエラー発生時、部分的に更新されてしまう

### DIFF
--- a/src/main/java/com/example/service/CampaignService.java
+++ b/src/main/java/com/example/service/CampaignService.java
@@ -130,7 +130,7 @@ public class CampaignService {
 				campaignRepository.save(campaign);
 			});
 		} catch (RuntimeException e) {
-			throw new Exception(e.getMessage());
+			throw new RuntimeException(e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
@Transactional(rollbackFor = RuntimeException.class) と指定しているので、catch内部の
throw new Exception(e.getMessage());
を
throw new RuntimeException(e.getMessage());
に編集してロールバックできるように修正